### PR TITLE
Nishant requests

### DIFF
--- a/R/pg_svy_years.R
+++ b/R/pg_svy_years.R
@@ -69,8 +69,9 @@ pg_national <-
   pg_area |>
   ftransform(area = "national") |>
   fgroup_by(id, area, welfare_type, survey_year) |>
-  fselect(pg, weight) |>
-  fmean(weight, stub = FALSE) |>
+  fselect(pg, sum.weight) |>
+  fmean(sum.weight, stub = FALSE) |>
+  frename(sum.weight = sum.sum.weight) |>
   fungroup()
 
 ## Append both ---------

--- a/R/pg_svy_years.R
+++ b/R/pg_svy_years.R
@@ -58,7 +58,7 @@ tictoc::toc()
 ## by area ---------
 pg_area <-
   dt |>
-  ftransform(pg = ps/welfare) |>
+  ftransform(pg = ps/welfare_ppp) |>
   fgroup_by(id, area) |>
   fselect(pg, weight) |>
   fmean(weight, stub = FALSE) |>

--- a/R/pg_svy_years.R
+++ b/R/pg_svy_years.R
@@ -59,7 +59,7 @@ tictoc::toc()
 pg_area <-
   dt |>
   ftransform(pg = ps/welfare_ppp) |>
-  fgroup_by(id, area) |>
+  fgroup_by(id, area, welfare_type, survey_year) |>
   fselect(pg, weight) |>
   fmean(weight, stub = FALSE) |>
   fungroup()
@@ -68,7 +68,7 @@ pg_area <-
 pg_national <-
   pg_area |>
   ftransform(area = "national") |>
-  fgroup_by(id, area) |>
+  fgroup_by(id, area, welfare_type, survey_year) |>
   fselect(pg, weight) |>
   fmean(weight, stub = FALSE) |>
   fungroup()


### PR DESCRIPTION
Hi @randrescastaneda, Nishant requested the following two additions:

1. pg should be calculated using the `welfare_ppp` rather than `welfare` vector
2. The data frame returned should also include a) survey year, b) welfare type

This PR suggests modifications in order to do the above. I also made a very small change to lines 68-75 that merely rename the columns. Without this renaming, the `rowbind` on line 78 produced in error. 

Lastly, I get a warning that `stub = FALSE` is an unused argument when passed to the S3 method `fmean.grouped_df()`. It does not make a difference, but just thought I would point it out. 

I checked that all the code ran for NPL, and it worked. 
